### PR TITLE
Bump textidote version from v0.8.2 to v0.8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,9 @@ jobs:
                   root_file: fine.tex
                   working_directory: test/
                   args: --check en
-                  threshold_error: 1 # by default the word 'linter' will be unknown
-            - name: Assert num_warnings == 1
-              if: ${{ steps.fine_spell_check.outputs.num_warnings != 1 }}
+                  threshold_error: 0
+            - name: Assert num_warnings == 0
+              if: ${{ steps.fine_spell_check.outputs.num_warnings != 0 }}
               run: 'echo "::error file=test/fine.tex::num_warnings: ${{ steps.fine_spell_check.outputs.num_warnings }}"; exit 1;'
             - name: Lint and spell-check fine.tex
               id: fine_spell_check_w_dict

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL vcs-type="git"
 
 ARG TEXTIDOTE_MAINTAINER=sylvainhalle
 ARG TEXTIDOTE_REPO=textidote
-ARG TEXTIDOTE_VERSION=v0.8.2
+ARG TEXTIDOTE_VERSION=v0.8.3
 
 RUN dnf install -y --setopt=install_weak_deps=False \
     bash \


### PR DESCRIPTION
I was getting some discrepancies between my local runs of textidote and the workflow runs, i think this might be the reason.

If you could update the action when you have time i would really appreciate it!