### PR TITLE
Use published image

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -67,6 +67,6 @@ jobs:
               uses: peter-evans/dockerhub-description@v3
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_PASSWORD }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
                   repository: gokhlayeh/textidote
                   readme-filepath: doc/docker/README.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
               uses: actions/checkout@v3
             - name: Lint fine.tex
               id: fine
-              uses: ./
+              uses: ./localAction
               with:
                   root_file: fine.tex
                   working_directory: test/
@@ -20,7 +20,7 @@ jobs:
               run: 'echo "::error file=test/fine.tex::num_warnings: ${{ steps.fine.outputs.num_warnings }}"; exit 1;'
             - name: Lint bad.tex with no threshold set
               id: bad_no_threshold
-              uses: ./
+              uses: ./localAction
               with:
                   root_file: bad.tex
                   working_directory: test/
@@ -29,7 +29,7 @@ jobs:
               run: 'echo "::error file=test/bad.tex::num_warnings: ${{ steps.bad_no_threshold.outputs.num_warnings }}"; exit 1;'
             - name: Lint bad.tex with threshold set to known warnings
               id: bad_known_threshold
-              uses: ./
+              uses: ./localAction
               with:
                   root_file: bad.tex
                   working_directory: test/
@@ -39,7 +39,7 @@ jobs:
               run: 'echo "::error file=test/bad.tex::num_warnings: ${{ steps.bad_known_threshold.outputs.num_warnings }}"; exit 1;'
             - name: Lint and spell-check fine.tex without dict
               id: fine_spell_check_wo_dict
-              uses: ./
+              uses: ./localAction
               with:
                   root_file: fine.tex
                   working_directory: test/
@@ -50,7 +50,7 @@ jobs:
               run: 'echo "::error file=test/fine.tex::num_warnings: ${{ steps.fine_spell_check_wo_dict.outputs.num_warnings }}"; exit 1;'
             - name: Lint and spell-check fine.tex with dict
               id: fine_spell_check_w_dict
-              uses: ./
+              uses: ./localAction
               with:
                   root_file: fine.tex
                   working_directory: test/

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ outputs:
         description: The number of warnings returned by TeXtidote.
 runs:
     using: docker
-    image: Dockerfile
+    image: gokhlayeh/textidote:latest
     args:
         - ${{ inputs.root_file }}
         - ${{ inputs.working_directory }}

--- a/localAction/action.yml
+++ b/localAction/action.yml
@@ -1,0 +1,38 @@
+name: Action-test
+description: GitHub Action to lint, spell- and grammar-check LaTeX documents using TeXtidote.
+author: Andreas Baulig
+inputs:
+    root_file:
+        description: The root LaTeX file to be linted.
+        required: true
+    working_directory:
+        description: Working directory to execute TeXtidote in.
+        required: false
+    report_type:
+        description: The type of TeXtidote report to generate (referring to TeXtidote's --output option).
+        default: 'html'
+    report_file:
+        description: The file path of TeXtidote report.
+        default: 'report.html'
+    threshold_error:
+        description: The threshold for the number of warnings from TeXtidote above which the build is marked unstable.
+        required: false
+    args:
+        description: Extra arguments to be passed to TeXtidote.
+        required: false
+outputs:
+    num_warnings:
+        description: The number of warnings returned by TeXtidote.
+runs:
+    using: docker
+    image: ../Dockerfile
+    args:
+        - ${{ inputs.root_file }}
+        - ${{ inputs.working_directory }}
+        - ${{ inputs.report_type }}
+        - ${{ inputs.report_file }}
+        - ${{ inputs.threshold_error }}
+        - ${{ inputs.args }}
+branding:
+    icon: type
+    color: blue


### PR DESCRIPTION
I moved the action to a folder to use it in testing and modified the action placed in the root folder to aim the published image.
This is the [testing repo of the action](https://github.com/marcosrmartin/pruebaTextidote) (I added an [extra test](https://github.com/marcosrmartin/pruebaTextidote/blob/main/.github/workflows/test.yml#L62-L71) to check also the published image), and [here](https://github.com/marcosrmartin/pruebaTextidote/commit/b8bb101b6ca4b75f412e54e03937a74d358f434c) is the last commit, which is passing both test (I didn't use/test the tag workflow).
This is my [dockerhub image generated](https://hub.docker.com/r/marcosrmartin/textidote) where the image has been published.